### PR TITLE
Add an option for keeping the arXiv ID in the BibTeX entry for published papers

### DIFF
--- a/arxivcheck/arxiv.py
+++ b/arxivcheck/arxiv.py
@@ -120,7 +120,7 @@ def get_arxiv_pdf_link(value, field="id"):
     return found, link
 
 
-def check_arxiv_published(value, field="id", get_first=True):
+def check_arxiv_published(value, field="id", get_first=True, keep_eprint=False):
     found = False
     published = False
     bib = ""
@@ -135,7 +135,8 @@ def check_arxiv_published(value, field="id", get_first=True):
         if "arxiv_doi" in item:
             doi = item["arxiv_doi"]
             published, bib = get_bib_from_doi(doi)
-            bib = add_eprint_to_bib(bib, value)
+            if keep_eprint:
+                bib = add_eprint_to_bib(bib, value)
         else:
             bib = generate_bib_from_arxiv(item, value, field)
     else:

--- a/arxivcheck/arxiv.py
+++ b/arxivcheck/arxiv.py
@@ -45,7 +45,7 @@ def get_arxiv_info(value, field="id"):
 
 def add_eprint_to_bib(bib, eprint):
     def bibtex_error():
-        raise RuntimeError, "CrossRef returned badly formed BibTeX file."
+        raise RuntimeError("CrossRef returned badly formed BibTeX file.")
 
     firstbrace = bib.find('{')
     if firstbrace == -1:

--- a/arxivcheck/arxiv.py
+++ b/arxivcheck/arxiv.py
@@ -136,7 +136,8 @@ def check_arxiv_published(value, field="id", get_first=True, keep_eprint=False):
             doi = item["arxiv_doi"]
             published, bib = get_bib_from_doi(doi)
             if keep_eprint:
-                bib = add_eprint_to_bib(bib, value)
+                eprint = re.split('/|v',item["id"])[-2]
+                bib = add_eprint_to_bib(bib, eprint)
         else:
             bib = generate_bib_from_arxiv(item, value, field)
     else:

--- a/arxivcheck/arxiv.py
+++ b/arxivcheck/arxiv.py
@@ -43,6 +43,28 @@ def get_arxiv_info(value, field="id"):
     return found, items
 
 
+def add_eprint_to_bib(bib, eprint):
+    def bibtex_error():
+        raise RuntimeError, "CrossRef returned badly formed BibTeX file."
+
+    firstbrace = bib.find('{')
+    if firstbrace == -1:
+        bibtex_error()
+
+    firstcomma = bib.find(',', firstbrace)
+    if firstcomma == -1:
+        bibtex_error()
+
+    firstnewline = bib.find('\n', firstcomma)
+    if firstnewline == -1:
+        bibtex_error()
+
+    bib = (bib[0:firstnewline] + '\n' + 
+           '        eprint={' + eprint + '},\n' +
+           '        archiveprefix={arXiv},' +
+           bib[firstnewline:])
+    return bib
+
 def generate_bib_from_arxiv(arxiv_item, value, field="id"):
     # arxiv_cat = arxiv_item.arxiv_primary_category["term"]
     if field == "ti":
@@ -113,6 +135,7 @@ def check_arxiv_published(value, field="id", get_first=True):
         if "arxiv_doi" in item:
             doi = item["arxiv_doi"]
             published, bib = get_bib_from_doi(doi)
+            bib = add_eprint_to_bib(bib, value)
         else:
             bib = generate_bib_from_arxiv(item, value, field)
     else:

--- a/arxivcheck/bin/arxivcheck
+++ b/arxivcheck/bin/arxivcheck
@@ -54,7 +54,11 @@ def main():
                         action="store_true",
                         help="don't get the first found"
                         )
-
+    parser.add_argument("--eprint", "-e",
+            dest="eprint",
+            action="store_true",
+            help="put the arXiv ID in the entry for a published paper"
+            )
 
     parser.set_defaults(ask=False)
     parser.set_defaults(title=False)
@@ -76,7 +80,7 @@ def main():
         arxivs = [arxiv for arxiv in arxivs.split("\n") if arxiv != ""]
     bibs = []
     for arxiv in arxivs:
-        found, published, bib = check_arxiv_published(arxiv, field, get_first)
+        found, published, bib = check_arxiv_published(arxiv, field, get_first, args[0].eprint)
         if found:
             bibs.append(bib)
     if len(bibs) > 0:


### PR DESCRIPTION
It's good practice to have the arXiv ID in the citation, even when the paper has been published. This pull request adds a command-line option "--eprint". When activated, the generated BibTeX entry for a published paper will include fields containing the arXiv ID. When using the Revtex 4.1 BibTeX style these will automatically lead to an arXiv ID and link appearing in the citation.